### PR TITLE
Add GNOME 44 support

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,7 +2,7 @@
   "name": "Activities Workspace Name",
   "description": "Replace Activities Text with Current Workspace Name",
   "uuid": "activitiesworkspacename@ahmafi.ir",
-  "shell-version": ["42", "43"],
+  "shell-version": ["42", "43", "44"],
   "url": "https://github.com/ahmafi/gnome-activities-workspace-name",
   "version": 2
 }


### PR DESCRIPTION
Working normally on Gnome 44:

[Screencast from 2023-04-30 22-34-26.webm](https://user-images.githubusercontent.com/17055027/235388384-c168dc89-4fc6-4dad-9913-62514a79208d.webm)
