### PR TITLE
Replace ?? with || for backward compatibility

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -105,7 +105,7 @@ var ActivitiesButton = GObject.registerClass(
       const activeWorkspaceIndex =
         global.workspace_manager.get_active_workspace_index();
       for (let i = 0; i < activeWorkspaceIndex; i++) {
-        workspaceNames[i] = workspaceNames[i] ?? "";
+        workspaceNames[i] = workspaceNames[i] || "";
       }
       workspaceNames[activeWorkspaceIndex] = name;
       this._wmSettings.set_strv("workspace-names", workspaceNames);


### PR DESCRIPTION
On Ubuntu 20.04, Gnome Shell 3.36 (I believe running on node 10) the [nullish coalescing operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) is causing an exception
```
JS ERROR: Extension activitiesworkspacename@ahmafi.ir: SyntaxError: expected expression, got '?' @ /home/username/.local/share/gnome-shell/extensions/activitiesworkspacename@ahmafi.ir/extension.js:108
```
This should be fine as we are talking about strings so the replacement would make sense for all falsy evaluations.